### PR TITLE
Fix bugs with collapseEpsilon and sbol.js

### DIFF
--- a/lib/graphDataOnEdges.js
+++ b/lib/graphDataOnEdges.js
@@ -614,7 +614,8 @@ function collapseEpsilons(stateGraph, eMap, nep) {
 function getEpsilonMap(stateGraph) {
   let eMap = {};
   for (let srcNode in stateGraph) {
-    for (let edge of stateGraph[srcNode].edges) {
+    if (stateGraph[srcNode].edges.length === 1) {
+      let edge = stateGraph[srcNode].edges[0];
       if (edge.type === EPSILON) {
         if (stateGraph[srcNode].operator.includes(OR) &&
           (stateGraph[edge.dest].operator.includes(ONE_MORE) || stateGraph[edge.dest].operator.includes(ZERO_MORE))) {
@@ -624,6 +625,23 @@ function getEpsilonMap(stateGraph) {
           eMap[edge.dest] = new Set();
         }
         eMap[edge.dest].add(edge.src);
+      }
+    } else {
+      for (let edge of stateGraph[srcNode].edges) {
+        if (edge.type === EPSILON) {
+          if (stateGraph[edge.dest].operator.includes(ONE_MORE) || stateGraph[edge.dest].operator.includes(ZERO_MORE)) {
+            continue;
+          }
+
+          if (stateGraph[srcNode].operator.includes(OR) &&
+            (stateGraph[edge.dest].operator.includes(ONE_MORE) || stateGraph[edge.dest].operator.includes(ZERO_MORE))) {
+            continue;
+          }
+          if (!(edge.dest in eMap)) {
+            eMap[edge.dest] = new Set();
+          }
+          eMap[edge.dest].add(edge.src);
+        }
       }
     }
   }

--- a/lib/sbol.js
+++ b/lib/sbol.js
@@ -61,7 +61,7 @@ function collapseStack(stack){
     }
   }
   if(stack.length > 2){
-    for(let i=0; i<stack.length; i++){
+    for(let i=0; i<stack.length-2; i++){
       let key = Object.keys(stack[i])[0];
       if (key === graph.ONE_MORE || key === graph.ZERO_SBOL){
         if (Object.keys(stack[i+1])[0] === graph.ATOM && Object.keys(stack[i+2])[0] === 'end'){


### PR DESCRIPTION
This is to stop collapseEpsilons() from deleting epsilon edges between two cycles.