### PR TITLE
Propagate reverse-comp to match new formalism.

### DIFF
--- a/lib/constellation.js
+++ b/lib/constellation.js
@@ -56,6 +56,9 @@ async function goldbar(langText, categories,
     throw new Error('Error parsing design specification')
   }
 
+  // Propagate `reverse-comp` operations to the atoms.
+  parsed = propagateReverseComplements(parsed);
+
   try {
     categories = parseCategories(categories);
   } catch (error) {
@@ -202,6 +205,68 @@ function parseGoldbar(langText) {
   langText = String(langText).replace('\t', ' ');
   langText = langText.trim();
   return imparse.parse(GRAMMAR_DEF, langText);
+}
+
+/**
+ * Propagates `reverse-comp` operations down to the atoms,
+ * reversing `then` nodes along the way.
+ * @param {Object} ast_node
+ * @param {boolean} reverse
+ * @returns {Object} Transformed GOLDBAR AST root node
+ */
+function propagateReverseComplements(ast_node, reverse) {
+  var reverse = (reverse == null) ? false : reverse;
+  var a = ast_node;
+  var rec = propagateReverseComplements;
+
+  if ("ReverseComp" in a) {
+    //a["ReverseComp"][0] = rec(a["ReverseComp"][0], reverse);
+    //return a;
+
+    return rec(a["ReverseComp"][0], !reverse);
+  } else if ("Then" in a) {
+    a["Then"][0] = rec(a["Then"][0], reverse);
+    a["Then"][1] = rec(a["Then"][1], reverse);
+    a["Then"] = reverse ? a["Then"].reverse() : a["Then"];
+    return a;
+  } else if ("Or" in a) {
+    a["Or"][0] = rec(a["Or"][0], reverse);
+    a["Or"][1] = rec(a["Or"][1], reverse);
+    return a;
+  } else if ("And0" in a) {
+    a["And0"][0] = rec(a["And0"][0], reverse);
+    a["And0"][1] = rec(a["And0"][1], reverse);
+    return a;
+  } else if ("And1" in a) {
+    a["And1"][0] = rec(a["And1"][0], reverse);
+    a["And1"][1] = rec(a["And1"][1], reverse);
+    return a;
+  } else if ("And2" in a) {
+    a["And2"][0] = rec(a["And2"][0], reverse);
+    a["And2"][1] = rec(a["And2"][1], reverse);
+    return a;
+  } else if ("Merge" in a) {
+    a["Merge"][0] = rec(a["Merge"][0], reverse);
+    a["Merge"][1] = rec(a["Merge"][1], reverse);
+    return a;
+  } else if ("OneOrMore" in a) {
+    a["OneOrMore"][0] = rec(a["OneOrMore"][0], reverse);
+    return a;
+  } else if ("ZeroOrOne" in a) {
+    a["ZeroOrOne"][0] = rec(a["ZeroOrOne"][0], reverse);
+    return a;
+  } else if ("ZeroOrMore" in a) {
+    a["ZeroOrMore"][0] = rec(a["ZeroOrMore"][0], reverse);
+    return a;
+  } else if ("ZeroOrOneSBOL" in a) {
+    a["ZeroOrOneSBOL"][0] = rec(a["ZeroOrOneSBOL"][0], reverse);
+    return a;
+  } else if ("ZeroOrMoreSBOL" in a) {
+    a["ZeroOrMoreSBOL"][0] = rec(a["ZeroOrMoreSBOL"][0], reverse);
+    return a;
+  } else if ("Atom" in a) {
+    return reverse ? {"ReverseComp": [a]} : a;
+  }
 }
 
 function parseCategories(categories) {

--- a/test/constellationTests.js
+++ b/test/constellationTests.js
@@ -64,8 +64,8 @@ function expectAConcatB(result, reverse=false) {
     partListA = revCompPart(partListA);
     partListB = revCompPart(partListB);
   }
-  expect(result.designs.length).to.equal(partListA.length + partListB.length);
-  expect(result.designs).to.have.members((partListA).concat(partListB));
+  expect(result.designs.length).to.equal(partListB.length + partListA.length);
+  expect(result.designs).to.have.members((partListB).concat(partListA));
 }
 
 function expectACartesianB(result, reverse=false) {


### PR DESCRIPTION
* Use new definition of `reverse-comp` that reverses the order of the children in all `then` nodes; adjust unit tests accordingly.
* Propagate all `reverse-comp` operations down to the atoms in the GOLDBAR abstract syntax tree before design enumeration begins.